### PR TITLE
refactor: daily now uses the fact api can take multiple packages

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var printJson bool
+
 var rootCmd = &cobra.Command{
 	Use:   "Cranlogs",
 	Short: "Access the cranlogs API",
@@ -25,4 +27,5 @@ func Execute() {
 
 func init() {
 	rootCmd.AddCommand(newDailyCmd())
+	rootCmd.PersistentFlags().BoolVar(&printJson, "json", false, "output in json format")
 }

--- a/internal/data/daily.go
+++ b/internal/data/daily.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
+	"strings"
 )
 
 type Daily struct {
@@ -18,31 +19,36 @@ type DailyDownload struct {
 	Downloads int    `json:"downloads"`
 }
 
-func GetDaily(period, pkg string) (Daily, error) {
+func GetDaily(period Period, pkgs []string) ([]Daily, error) {
 	// weirdly the API returns an array of length 1
 	var daily []Daily
-
-	path := URL + "downloads/daily/" + period + "/" + pkg
-
+	path := URL + "downloads/daily/" + string(period) + "/" + strings.Join(pkgs, ",")
 	resp, err := http.Get(path)
 
 	if err != nil {
-		return Daily{}, err
+		return daily, err
 	}
-
+	// This is currently kind of meaningless until
+	// https://github.com/r-hub/cranlogs.app/issues/41 is resolved but at least
+	// its there
+	if resp.StatusCode != 200 {
+		return daily, err
+	}
 	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
 
 	if err != nil {
-		return Daily{}, err
+		return daily, err
 	}
 
 	err = json.Unmarshal(body, &daily)
-
+	// if this errors given the current 200 status code returning an error response
+	// such as { "error": "Invalid query",   "info": "https://github.com/metacran/cranlogs.app" }
+	// its still not the best error code
 	if err != nil {
-		return Daily{}, err
+		return daily, err
 	}
 
-	return daily[0], nil
+	return daily, nil
 }


### PR DESCRIPTION
This refactors daily to take advantage of don't need to make multiple requests as its valid to include a comma separated package list

This is also why (to your question/comment in the code) why even for a single package it returns an array, to keep the return structure consistent whether single or multiple packages (i presume at least)

In addition, I added the conditional capability to return json - this would make it easier to interact with this in programmatic settings/compose with other tools