### PR TITLE
ci: add test + release infra

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,91 @@
+name: build
+
+on:
+  push:
+    branches:
+      - 'main'
+    tags:
+      - 'v*'
+  pull_request:
+
+permissions:
+  contents: write
+  id-token: write
+  packages: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_CLI_EXPERIMENTAL: "enabled"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: arduino/setup-task@v1
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/setup-qemu-action@v1
+      - uses: docker/setup-buildx-action@v1
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.17'
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ./dist/*.deb
+            ./dist/*.rpm
+            ./dist/*.apk
+          key: ${{ runner.os }}-go-${{ hashFiles('**/*.go') }}-${{ hashFiles('go.sum') }}--${{ hashFiles('.goreleaser.yml') }}
+      - run: task ci
+      - uses: codecov/codecov-action@v2
+        with:
+          file: ./coverage.txt
+      - run: git diff
+      - name: Install GoReleaser
+        if: startsWith(github.ref, 'refs/tags/v') ||  github.ref == 'refs/heads/main'
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          install-only: true
+      - name: goreleaser-release
+        if: startsWith(github.ref, 'refs/tags/v') ||  github.ref == 'refs/heads/main'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          FURY_TOKEN: ${{ secrets.FURY_TOKEN }}
+        run: task goreleaser
+  cranlogs-check-pkgs:
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_CLI_EXPERIMENTAL: "enabled"
+    needs:
+      - goreleaser
+    if: github.ref == 'refs/heads/main'
+    strategy:
+      matrix:
+        format: [ deb, rpm, apk ]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: arduino/setup-task@v1
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/setup-qemu-action@v1
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ./dist/*.deb
+            ./dist/*.rpm
+            ./dist/*.apk
+          key: ${{ runner.os }}-go-${{ hashFiles('**/*.go') }}-${{ hashFiles('go.sum') }}--${{ hashFiles('.goreleaser.yml') }}
+      - run: task cranlogs:test:${{ matrix.format }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,93 @@
+project_name: cranlogs
+
+release:
+  # in case there is an indicator for this in the tag e.g. v1.0.0-rc1
+  # If set to true, will mark the release as not ready for production.
+  # Default is false.
+  prerelease: auto
+
+before:
+  hooks:
+    - go mod tidy
+    - ./scripts/completions.sh
+    - ./scripts/manpages.sh
+
+builds:
+  - 
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - windows
+      - darwin
+      - linux
+    goarch:
+    - amd64
+    - arm64
+    - arm
+    goarm:
+    - "7"
+
+archives:
+  - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+    replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      amd64: x86_64
+    format_overrides:
+    - goos: windows
+      format: zip
+    files:
+      - README.md
+      - LICENSE
+      - completions/*
+      - manpages/*   
+
+brews:
+  # Repository to push the tap to.
+  -
+    tap:
+      owner: devOpifex 
+      name: homebrew-tap 
+    folder: Formula
+    goarm: "7"
+    test: |
+      system "#{bin}/cranlogs -v"
+    install: |-
+      bin.install "cranlogs"
+      bash_completion.install "completions/cranlogs.bash" => "cranlogs"
+      zsh_completion.install "completions/cranlogs.zsh" => "_cranlogs"
+      fish_completion.install "completions/cranlogs.fish"
+      man1.install "manpages/cranlogs.1.gz"
+
+publishers:
+  - name: fury.io
+    ids:
+    - packages
+    env:
+    - 'FURY_TOKEN={{ .Env.FURY_TOKEN }}'
+    cmd: ./scripts/fury-upload.sh {{ .ArtifactName }}
+
+nfpms:
+  - file_name_template: '{{ .ConventionalFileName }}'
+    id: packages
+    homepage:  https://github.com/devOpifex/cranlogs
+    description: Access cranlogs from the command line 
+    maintainer: John Coene <john@opifex.org>
+    license: MIT
+    contents:
+      - src: ./completions/cranlogs.bash
+        dst: /etc/bash_completion.d/cranlogs
+      - src: ./completions/cranlogs.fish
+        dst: /usr/share/fish/completions/cranlogs.fish
+      - src: ./completions/cranlogs.zsh
+        dst: /usr/local/share/zsh/site-functions/_cranlogs
+      - src: ./manpages/cranlogs.1.gz
+        dst: /usr/share/man/man1/cranlogs.1.gz
+    formats:
+    - apk
+    - deb
+    - rpm
+
+snapshot:
+  name_template: '{{ incpatch .Version }}-next'

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,159 @@
+# https://taskfile.dev
+
+version: '3'
+
+env:
+  GO111MODULE: on
+  GOPROXY: https://proxy.golang.org,direct
+
+vars:
+  DOCKER: '{{default "docker" .DOCKER}}'
+
+tasks:
+  setup:
+    desc: Install dependencies
+    cmds:
+      - go mod tidy
+
+  build:
+    desc: Build the binary
+    sources:
+      - ./**/*.go
+    generates:
+      - ./cranlogs
+    cmds:
+      - go build
+
+  test:
+    desc: Run tests
+    env:
+      LC_ALL: C
+    vars:
+      TEST_OPTIONS: '{{default "" .TEST_OPTIONS}}'
+      SOURCE_FILES: '{{default "./..." .SOURCE_FILES}}'
+      TEST_PATTERN: '{{default "." .TEST_PATTERN}}'
+    cmds:
+      - go test {{.TEST_OPTIONS}} -failfast -race -coverpkg=./... -covermode=atomic -coverprofile=coverage.txt {{.SOURCE_FILES}} -run {{.TEST_PATTERN}} -timeout=5m
+
+  cover:
+    desc: Open the cover tool
+    cmds:
+      - go tool cover -html=coverage.txt
+
+  fmt:
+    desc: gofumpt all code
+    cmds:
+      - gofumpt -w -l .
+
+  lint:
+    desc: Lint the code with golangci-lint
+    cmds:
+      - golangci-lint run ./...
+
+  ci:
+    desc: Run all CI steps
+    cmds:
+      - task: setup
+      - task: build
+      - task: test
+
+  default:
+    desc: Runs the default tasks
+    cmds:
+      - task: ci
+
+  release:
+    desc: Create a new tag
+    vars:
+      NEXT:
+      # https://github.com/caarlos0/svu
+        sh: svu n
+    cmds:
+      - git tag {{.NEXT}}
+      - echo {{.NEXT}}
+      - git push origin --tags
+
+  cranlogs:test:pkg:
+    desc: Test a package
+    cmds:
+      - docker run --platform linux/{{.Platform}} --rm --workdir /tmp -v $PWD/dist:/tmp {{.Image}} sh -c '{{.Cmd}} && cranlogs --version'
+
+  cranlogs:test:rpm:
+    desc: Tests rpm packages
+    vars:
+      rpm: 'rpm --nodeps -ivh'
+    cmds:
+      - task: cranlogs:test:pkg
+        vars:
+          Platform: 'amd64'
+          Image: fedora
+          Cmd: '{{.rpm}} cranlogs-*.x86_64.rpm'
+      - task: cranlogs:test:pkg
+        vars:
+          Platform: 'arm64'
+          Image: fedora
+          Cmd: '{{.rpm}} cranlogs-*.aarch64.rpm'
+      - task: cranlogs:test:pkg
+        vars:
+          Platform: 'arm/7'
+          Image: fedora
+          Cmd: '{{.rpm}} cranlogs-*.armv7hl.rpm'
+
+  cranlogs:test:deb:
+    desc: Tests deb packages
+    vars:
+      dpkg: 'dpkg -i'
+    cmds:
+      - task: cranlogs:test:pkg
+        vars:
+          Platform: 'amd64'
+          Image: ubuntu
+          Cmd: '{{.dpkg}} cranlogs*_amd64.deb'
+      - task: cranlogs:test:pkg
+        vars:
+          Platform: 'arm64'
+          Image: ubuntu
+          Cmd: '{{.dpkg}} cranlogs*_arm64.deb'
+      - task: cranlogs:test:pkg
+        vars:
+          Platform: 'arm/7'
+          Image: ubuntu
+          Cmd: '{{.dpkg}} cranlogs*_armhf.deb'
+
+  cranlogs:test:apk:
+    desc: Tests apk packages
+    vars:
+      apk: 'apk add --allow-untrusted -U'
+    cmds:
+      - task: cranlogs:test:pkg
+        vars:
+          Platform: 'amd64'
+          Image: alpine
+          Cmd: '{{.apk}} cranlogs*_x86_64.apk'
+      - task: cranlogs:test:pkg
+        vars:
+          Platform: 'arm64'
+          Image: alpine
+          Cmd: '{{.apk}} cranlogs*_aarch64.apk'
+      - task: cranlogs:test:pkg
+        vars:
+          Platform: 'arm/7'
+          Image: alpine
+          Cmd: '{{.apk}} cranlogs*_armv7.apk'
+
+  cranlogs:test:
+    desc: Test built linux packages
+    cmds:
+      - task: cranlogs:test:apk
+      - task: cranlogs:test:deb
+      - task: cranlogs:test:rpm
+
+  goreleaser:
+    desc: Run GoReleaser either in snapshot or release mode
+    deps:
+      - build
+    vars:
+      SNAPSHOT:
+        sh: 'if [[ $GITHUB_REF != refs/tags/v* ]]; then echo "--snapshot"; fi'
+    cmds:
+      - goreleaser release --rm-dist {{.SNAPSHOT}}


### PR DESCRIPTION
alrighty, so lets break this down. 

There are two things being added here:

1) a `.Taskfile.yml` - which is https://github.com/go-task/task a nice crossplatform alternative to make. This is where most of the plumbing lives and can be run outside of the CI system. 

2)The github actions build

All the CI stuff is heavily focused on running on `main` or in a `tag` as it currently exists. I will comment on pieces inline to describe in more detail. 

In order to get this to work fully, you'll need to add two secrets for your actions:

![image](https://user-images.githubusercontent.com/3196313/152276813-d10f9f83-76d2-4759-8d6b-5003743bda3c.png)

for the github token it should be a PAT with repo scopes:

<img width="1103" alt="Screen Shot 2022-02-02 at 1 35 48 PM" src="https://user-images.githubusercontent.com/3196313/152276969-5dfd74c9-6a10-43db-aec9-2861b4d9b1ab.png">


The reason its not named GITHUB_TOKEN (even though thats what goreleaser wants) is GITHUB_* is actually a reserved phrase for github actions.


The FURY_TOKEN will be a new PUSH token that looks like:

<img width="977" alt="Screen Shot 2022-01-29 at 4 42 21 PM" src="https://user-images.githubusercontent.com/3196313/152276904-09d0dbd5-6119-4cec-8f9f-c36e7c744038.png">



Finally, to use you'll want to make the packaging on fury public:

<img width="977" alt="Screen Shot 2022-01-29 at 4 52 42 PM" src="https://user-images.githubusercontent.com/3196313/152276927-499ac819-9b8c-46c5-8364-20e0e49307bc.png">
