### PR TITLE
feat: add version information

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,7 +8,6 @@ import (
 )
 
 var printJson bool
-
 var rootCmd = &cobra.Command{
 	Use:   "Cranlogs",
 	Short: "Access the cranlogs API",
@@ -18,7 +17,9 @@ var rootCmd = &cobra.Command{
 	},
 }
 
-func Execute() {
+func Execute(version string) {
+	rootCmd.Version = version
+	rootCmd.SetVersionTemplate(`{{printf "%s\n" .Version}}`)
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -2,6 +2,13 @@ package main
 
 import "github.com/devOpifex/cranlogs/cmd"
 
+var (
+	version string = "dev"
+	// goreleaser will also inject these if desireable to use
+	// commit  string = "none"
+	// date    string = "unknown"
+)
+
 func main() {
-	cmd.Execute()
+	cmd.Execute(version)
 }


### PR DESCRIPTION
By setting the version information, this autopopulates the `-v` and `--version` flags to be useable

for example, now:

```
❯ go run main.go --version
dev
```


This should fix the build failures https://github.com/devOpifex/cranlogs/runs/5147713836?check_suite_focus=true:

```
Setting up cranlogs (0.0.2~next) ...
Error: unknown flag: --version
Usage:
unknown flag: --version
```